### PR TITLE
Update bootstrap.offcanvas.css

### DIFF
--- a/dist/css/bootstrap.offcanvas.css
+++ b/dist/css/bootstrap.offcanvas.css
@@ -1,4 +1,4 @@
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .navbar-offcanvas {
     position: fixed;
     height: 100%;


### PR DESCRIPTION
Set max-width 767px so it conforms with the bootstrap grid-break for xs-devices. It caused disappearance of the menu but still leaving whitespace on iPad (portrait orientation)