### PR TITLE
Ensure wiredep compatiblity

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "Phil Hughes <me@iamphill.com>"
   ],
   "main": [
-    "dist/css/bootstrap.offcanvas.min.css",
+    "dist/css/bootstrap.offcanvas.css",
     "dist/js/bootstrap.offcanvas.js"
   ],
   "license": "MIT",


### PR DESCRIPTION
gulp-wiredep doesn't like specifying minified files as main files.

To address this and assuring compatibility, reference the unminified css file.