### PR TITLE
Fixed - #60 Dropdowns don't open in desktop view

### DIFF
--- a/dist/js/bootstrap.offcanvas.js
+++ b/dist/js/bootstrap.offcanvas.js
@@ -27,7 +27,7 @@
         e.stopPropagation();
         $('.dropdown-toggle').not(this.element).closest('.active').removeClass('active').find('.dropdown-menu').removeClass('shown');
         this.dropdown.toggleClass("shown");
-        return this.element.parent().toggleClass('active');
+        return this.element.parent().toggleClass('open');
       };
 
       return OffcanvasDropdown;


### PR DESCRIPTION
The drop down parent class is open in bootstrap navbar - https://getbootstrap.com/docs/3.3/components/#navbar  