### PR TITLE
Fixed - #60 Dropdowns don't open in desktop view

### DIFF
--- a/src/coffee/bootstrap.offcanvas.coffee
+++ b/src/coffee/bootstrap.offcanvas.coffee
@@ -31,7 +31,7 @@
 
             # Show or hide element
             @dropdown.toggleClass "shown"
-            @element.parent().toggleClass 'active'
+            @element.parent().toggleClass 'open'
 
     class OffcanvasTouch
         #   Public: Constructor for offcanvas


### PR DESCRIPTION
The drop down parent class is open in bootstrap navbar - https://getbootstrap.com/docs/3.3/components/#navbar